### PR TITLE
Imorting pages instead of vpages 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+data
+src/tseda/_version.py

--- a/src/tseda/__main__.py
+++ b/src/tseda/__main__.py
@@ -9,7 +9,7 @@ import panel as pn  # noqa
 from . import app  # noqa
 from . import config  # noqa
 from . import model  # noqa
-from . import vpages  # noqa, no module named pages but one named vpages
+from . import vpages  # noqa
 from . import datastore  # noqa
 from .datastore import IndividualsTable  # noqa
 from tsbrowse import preprocess as preprocess_  # noqa

--- a/src/tseda/__main__.py
+++ b/src/tseda/__main__.py
@@ -9,7 +9,7 @@ import panel as pn  # noqa
 from . import app  # noqa
 from . import config  # noqa
 from . import model  # noqa
-from . import pages  # noqa
+from . import vpages  # noqa, no module named pages but one named vpages
 from . import datastore  # noqa
 from .datastore import IndividualsTable  # noqa
 from tsbrowse import preprocess as preprocess_  # noqa


### PR DESCRIPTION
There seems to be an error in the imports in `.../tseda/src/tseda/__main__.py`
Row 12 should say` from . import vpages `instead of `from . import pages`, otherwise you get the following error:


```diff
-  File ".../tseda/src/tseda/__main__.py", line 12, in <module>
-  from . import pages  # noqa
- ImportError: cannot import name 'pages' from 'tseda' (.../tseda/src/tseda/__init__.py). Did you mean: 'vpages'?


```
This PR changes pages to vpages.